### PR TITLE
Provide support for unittest.mock.patch autospeccing

### DIFF
--- a/barin/field.py
+++ b/barin/field.py
@@ -61,7 +61,10 @@ class Field(object):
         inst[self._name] = self._schema.validate(value)
 
     def __getattr__(self, name):
-        return self[name]
+        try:
+            return self[name]
+        except TypeError:
+            raise AttributeError(name)
 
     def __getitem__(self, name):
         from barin import manager

--- a/barin/manager/class_manager.py
+++ b/barin/manager/class_manager.py
@@ -20,7 +20,11 @@ class ClassManager(object):
         return getattr(self._reg, name)
 
     def __dir__(self):
-        return dir(self._reg) + list(self.__dict__.keys())
+        return (
+            dir(self._reg)
+            + list(self.__dict__.keys())
+            + list(self.__class__.__dict__.keys())
+        )
 
     def __getitem__(self, name):
         return self._reg[name]


### PR DESCRIPTION
Ensure that Manager and Field types are able to correctly report attributes so that `unittest.mock.patch()` can iterate the attributes during autospeccing and replace them with mock methods.